### PR TITLE
Session 5 sp18

### DIFF
--- a/session5/Session 5 Solutions.ipynb
+++ b/session5/Session 5 Solutions.ipynb
@@ -448,7 +448,7 @@
     "\n",
     "1.  All the files on the system are organized into a hierarchy.\n",
     "2.  Your home folder, which is named after your username, lives inside a folder called `class`.\n",
-    "3.  That folder in turn lives inside a folder called `fa17`.\n",
+    "3.  That folder in turn lives inside a folder named after the current semester.\n",
     "4.  That folder in turn lives inside a folder named after whatever class the account you're using was issued for.\n",
     "5.  That folder in turn lives inside a folder named `cc`.\n",
     "6.  That folder in turn lives inside a folder named `home`.\n",

--- a/session5/Session 5.ipynb
+++ b/session5/Session 5.ipynb
@@ -319,7 +319,7 @@
     "\n",
     "1.  All the files on the system are organized into a hierarchy.\n",
     "2.  Your home folder, which is named after your username, lives inside a folder called `class`.\n",
-    "3.  That folder in turn lives inside a folder called `fa17`.\n",
+    "3.  That folder in turn lives inside a folder named after the current semester.\n",
     "4.  That folder in turn lives inside a folder named after whatever class the account you're using was issued for.\n",
     "5.  That folder in turn lives inside a folder named `cc`.\n",
     "6.  That folder in turn lives inside a folder named `home`.\n",

--- a/session5/deborahscript.py
+++ b/session5/deborahscript.py
@@ -11,7 +11,7 @@ from __future__ import print_function
 
 # Cats Everywhere
 import ast
-from textx import metamodel
+from textx import metamodel_from_file
 
 import sys
 
@@ -164,10 +164,10 @@ class Evaluator(ast.NodeVisitor):
         return float(raw_input())
 
     
-model = metamodel.metamodel_from_file("deborahscript.tx", classes=[Program, Loop, Assignment, Declaration,
-                                                                   Print, Expression, BinaryExpression,
-                                                                   Variable, LUT, IntInput, StrInput, FloatInput,
-                                                                   FloatLiteral, NumberLiteral, StringLiteral])
+model = metamodel_from_file("deborahscript.tx", classes=[Program, Loop, Assignment, Declaration,
+                                                         Print, Expression, BinaryExpression,
+                                                         Variable, LUT, IntInput, StrInput, FloatInput,
+                                                         FloatLiteral, NumberLiteral, StringLiteral])
 
 
 def run(filename):

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -1,5 +1,9 @@
 textX
 jupyter
-ipython
+ipython<6
 scikit-image
 scikit-learn
+
+# Newer versions of tornado do not like using Python 2.7 on Ubuntu Trusty
+# (14.04) because it does not include the needed SSL extensions
+tornado<5

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -1,9 +1,5 @@
 textX
 jupyter
-ipython<6
+ipython
 scikit-image
 scikit-learn
-
-# Newer versions of tornado do not like using Python 2.7 on Ubuntu Trusty
-# (14.04) because it does not include the needed SSL extensions
-tornado<5


### PR DESCRIPTION
A couple small fixes for session 5. I had to pin some dependencies in `requirements.txt` to avoid using newer versions that don't work well with the (fairly ancient) version of Python 2 on the lab machines (2.7.6). I also fixed a problem in the deborahscript interpreter that occurs with a newer version of textx and removed some references to fa17 and replaced them with more generic references to avoid having to continually update them in the future.